### PR TITLE
Add test projects

### DIFF
--- a/SpotifyMusicChatBot.Tests.Integration/Controllers/ChatControllerTests.cs
+++ b/SpotifyMusicChatBot.Tests.Integration/Controllers/ChatControllerTests.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+using SpotifyMusicChatBot.API.Application.Command.SaveConversation;
+using SpotifyMusicChatBot.Tests.Integration.Infrastructure;
+
+namespace SpotifyMusicChatBot.Tests.Integration.Controllers;
+
+public class ChatControllerTests : IClassFixture<TestApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public ChatControllerTests(TestApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PostConversation_ReturnsOk()
+    {
+        var request = new SaveConversationRequest { UserPrompt = "hi", AiResponse = "hello" };
+        var response = await _client.PostAsJsonAsync("/api/chat/conversation", request);
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task GetSessionSummary_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync("/api/chat/conversation/123/summary");
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/SpotifyMusicChatBot.Tests.Integration/Infrastructure/FakeChatBotRepository.cs
+++ b/SpotifyMusicChatBot.Tests.Integration/Infrastructure/FakeChatBotRepository.cs
@@ -1,0 +1,38 @@
+using SpotifyMusicChatBot.Domain.Application.Model.Conversation;
+using SpotifyMusicChatBot.Domain.Application.Model.Search;
+using SpotifyMusicChatBot.Domain.Application.Repository;
+
+namespace SpotifyMusicChatBot.Tests.Integration.Infrastructure;
+
+public class FakeChatBotRepository : IChatBotRepository
+{
+    private readonly List<ConversationTurn> _turns = new();
+
+    public string GenerateSessionId() => Guid.NewGuid().ToString();
+
+    public Task<bool> SaveConversationAsync(string userPrompt, string aiResponse, string sessionId)
+    {
+        _turns.Add(new ConversationTurn
+        {
+            Id = _turns.Count + 1,
+            Timestamp = DateTime.UtcNow,
+            UserPrompt = userPrompt,
+            AiResponse = aiResponse,
+        });
+        return Task.FromResult(true);
+    }
+
+    public Task<IEnumerable<ConversationSession>> GetAllConversationsAsync() =>
+        Task.FromResult<IEnumerable<ConversationSession>>(new List<ConversationSession>());
+
+    public Task<IEnumerable<ConversationTurn>> GetConversationBySessionIdAsync(string sessionId) =>
+        Task.FromResult<IEnumerable<ConversationTurn>>(_turns);
+
+    public Task<SessionSummary?> GetSessionSummaryAsync(string sessionId) =>
+        Task.FromResult<SessionSummary?>(null);
+
+    public Task<bool> DeleteSessionAsync(string sessionId) => Task.FromResult(true);
+
+    public Task<IEnumerable<SearchResult>> SearchConversationsAsync(string searchTerm) =>
+        Task.FromResult<IEnumerable<SearchResult>>(new List<SearchResult>());
+}

--- a/SpotifyMusicChatBot.Tests.Integration/Infrastructure/TestApiFactory.cs
+++ b/SpotifyMusicChatBot.Tests.Integration/Infrastructure/TestApiFactory.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SpotifyMusicChatBot.API;
+using SpotifyMusicChatBot.Domain.Application.Repository;
+
+namespace SpotifyMusicChatBot.Tests.Integration.Infrastructure;
+
+public class TestApiFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Replace repository with fake implementation
+            var descriptor = services.SingleOrDefault(s => s.ServiceType == typeof(IChatBotRepository));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+            services.AddSingleton<IChatBotRepository, FakeChatBotRepository>();
+        });
+    }
+}

--- a/SpotifyMusicChatBot.Tests.Integration/SpotifyMusicChatBot.Tests.Integration.csproj
+++ b/SpotifyMusicChatBot.Tests.Integration/SpotifyMusicChatBot.Tests.Integration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.1310" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SpotifyMusicChatBot.API\SpotifyMusicChatBot.API.csproj" />
+    <ProjectReference Include="..\SpotifyMusicChatBot.Domain\SpotifyMusicChatBot.Domain.csproj" />
+    <ProjectReference Include="..\SpotifyMusicChatBot.Infra\SpotifyMusicChatBot.Infra.csproj" />
+  </ItemGroup>
+</Project>

--- a/SpotifyMusicChatBot.Tests.Unit/Handlers/DeleteSessionHandlerTests.cs
+++ b/SpotifyMusicChatBot.Tests.Unit/Handlers/DeleteSessionHandlerTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using SpotifyMusicChatBot.API.Application.Command.DeleteSession;
+using SpotifyMusicChatBot.Domain.Application.Repository;
+
+namespace SpotifyMusicChatBot.Tests.Unit.Handlers;
+
+public class DeleteSessionHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenRepositoryReturnsFalse()
+    {
+        // Arrange
+        var repoMock = new Mock<IChatBotRepository>();
+        repoMock.Setup(r => r.DeleteSessionAsync("session1")).ReturnsAsync(false);
+
+        var loggerMock = new Mock<ILogger<DeleteSessionHandler>>();
+        var handler = new DeleteSessionHandler(repoMock.Object, loggerMock.Object);
+
+        var request = new DeleteSessionRequest { SessionId = "session1" };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Sesión no encontrada", result.Message);
+    }
+}

--- a/SpotifyMusicChatBot.Tests.Unit/Handlers/SaveConversationHandlerTests.cs
+++ b/SpotifyMusicChatBot.Tests.Unit/Handlers/SaveConversationHandlerTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using SpotifyMusicChatBot.API.Application.Command.SaveConversation;
+using SpotifyMusicChatBot.Domain.Application.Repository;
+
+namespace SpotifyMusicChatBot.Tests.Unit.Handlers;
+
+public class SaveConversationHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenRepositorySavesConversation()
+    {
+        // Arrange
+        var repoMock = new Mock<IChatBotRepository>();
+        repoMock.Setup(r => r.GenerateSessionId()).Returns("session1");
+        repoMock.Setup(r => r.SaveConversationAsync(It.IsAny<string>(), It.IsAny<string>(), "session1"))
+            .ReturnsAsync(true);
+
+        var loggerMock = new Mock<ILogger<SaveConversationHandler>>();
+        var handler = new SaveConversationHandler(repoMock.Object, loggerMock.Object);
+
+        var request = new SaveConversationRequest { UserPrompt = "hi", AiResponse = "hello" };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal("session1", result.SessionId);
+    }
+}

--- a/SpotifyMusicChatBot.Tests.Unit/Handlers/SearchConversationsHandlerTests.cs
+++ b/SpotifyMusicChatBot.Tests.Unit/Handlers/SearchConversationsHandlerTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using SpotifyMusicChatBot.API.Application.Query.SearchConversations;
+using SpotifyMusicChatBot.Domain.Application.Repository;
+
+namespace SpotifyMusicChatBot.Tests.Unit.Handlers;
+
+public class SearchConversationsHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsBadRequest_WhenSearchTermIsEmpty()
+    {
+        var repoMock = new Mock<IChatBotRepository>();
+        var loggerMock = new Mock<ILogger<SearchConversationsHandler>>();
+        var handler = new SearchConversationsHandler(repoMock.Object, loggerMock.Object);
+
+        var request = new SearchConversationsRequest { SearchTerm = "" };
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal("El término de búsqueda es requerido", result.Message);
+    }
+}

--- a/SpotifyMusicChatBot.Tests.Unit/SpotifyMusicChatBot.Tests.Unit.csproj
+++ b/SpotifyMusicChatBot.Tests.Unit/SpotifyMusicChatBot.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.1310" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SpotifyMusicChatBot.API\SpotifyMusicChatBot.API.csproj" />
+    <ProjectReference Include="..\SpotifyMusicChatBot.Domain\SpotifyMusicChatBot.Domain.csproj" />
+    <ProjectReference Include="..\SpotifyMusicChatBot.Infra\SpotifyMusicChatBot.Infra.csproj" />
+  </ItemGroup>
+</Project>

--- a/SpotifyMusicChatBot.sln
+++ b/SpotifyMusicChatBot.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyMusicChatBot.Domain"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyMusicChatBot.Infra", "SpotifyMusicChatBot.Infra\SpotifyMusicChatBot.Infra.csproj", "{68779A1F-200C-4C31-8623-BC919E269141}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyMusicChatBot.Tests.Unit", "SpotifyMusicChatBot.Tests.Unit\SpotifyMusicChatBot.Tests.Unit.csproj", "{DE241ECC-CBA9-47C0-9CDE-198D9CB32E6A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpotifyMusicChatBot.Tests.Integration", "SpotifyMusicChatBot.Tests.Integration\SpotifyMusicChatBot.Tests.Integration.csproj", "{1BD31A4E-A425-4BBF-89BA-502EF7BC3A2C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +34,13 @@ Global
 		{68779A1F-200C-4C31-8623-BC919E269141}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68779A1F-200C-4C31-8623-BC919E269141}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68779A1F-200C-4C31-8623-BC919E269141}.Release|Any CPU.Build.0 = Release|Any CPU
+                {DE241ECC-CBA9-47C0-9CDE-198D9CB32E6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DE241ECC-CBA9-47C0-9CDE-198D9CB32E6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DE241ECC-CBA9-47C0-9CDE-198D9CB32E6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DE241ECC-CBA9-47C0-9CDE-198D9CB32E6A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1BD31A4E-A425-4BBF-89BA-502EF7BC3A2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1BD31A4E-A425-4BBF-89BA-502EF7BC3A2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1BD31A4E-A425-4BBF-89BA-502EF7BC3A2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1BD31A4E-A425-4BBF-89BA-502EF7BC3A2C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xunit test projects for unit and integration tests
- implement sample unit tests for handlers
- implement integration tests for `ChatController`
- register test projects in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b16f3df48325b365259577d130e2